### PR TITLE
Add basic user authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ DB_USER=root
 DB_PASS=123123            # en blanco si no configuraste contraseña
 DB_NAME=puka_local
 DB_PORT=3306
+JWT_SECRET=your_jwt_secret

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ DB_HOST=localhost
 DB_USER=tu_usuario
 DB_PASSWORD=tu_clave
 DB_NAME=nombre_bd
+JWT_SECRET=tu_clave_secreta
 
 3. Ejecutar el proyecto:
 npm run dev
@@ -73,6 +74,15 @@ POST /api/categories
 PUT /api/categories/:id
 
 DELETE /api/categories/:id
+
+👤 Usuarios
+POST /api/users/register
+
+POST /api/users/login
+
+PUT /api/users/:id/password
+
+DELETE /api/users/:id
 
 🔐 Validaciones implementadas
 Verificación de campos obligatorios

--- a/package.json
+++ b/package.json
@@ -16,12 +16,16 @@
   "devDependencies": {
     "@types/express": "^5.0.2",
     "@types/node": "^22.15.21",
+    "@types/bcrypt": "^5.0.0",
+    "@types/jsonwebtoken": "^9.0.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.8.3"
   },
   "dependencies": {
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
-    "mysql2": "^3.14.1"
+    "mysql2": "^3.14.1",
+    "bcrypt": "^5.1.1",
+    "jsonwebtoken": "^9.0.2"
   }
 }

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -1,0 +1,81 @@
+import { Request, Response } from 'express';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import {
+  createUser,
+  getUserByEmail,
+  getUserById,
+  updateUserPassword,
+  deleteUser
+} from '../services/user.service';
+import { AppError } from '../utils/AppError';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+
+export async function register(req: Request, res: Response) {
+  const { email, password, name } = req.body;
+
+  if (!email) throw new AppError('El campo "email" es obligatorio', 400);
+  if (!password) throw new AppError('El campo "password" es obligatorio', 400);
+
+  const existing = await getUserByEmail(email);
+  if (existing) {
+    throw new AppError('El email ya está registrado', 400);
+  }
+
+  await createUser({ email, password, name });
+  res.status(201).json({ message: 'Usuario creado correctamente' });
+}
+
+export async function login(req: Request, res: Response) {
+  const { email, password } = req.body;
+
+  if (!email || !password) {
+    throw new AppError('Email y password son obligatorios', 400);
+  }
+
+  const user = await getUserByEmail(email);
+  if (!user) {
+    throw new AppError('Credenciales inválidas', 401);
+  }
+
+  const valid = await bcrypt.compare(password, user.password);
+  if (!valid) {
+    throw new AppError('Credenciales inválidas', 401);
+  }
+
+  const token = jwt.sign({ id: user.id, email: user.email }, JWT_SECRET, {
+    expiresIn: '1h'
+  });
+
+  res.json({ token, user: { id: user.id, email: user.email, name: user.name } });
+}
+
+export async function changePassword(req: Request, res: Response) {
+  const id = Number(req.params.id);
+  const { currentPassword, newPassword } = req.body;
+
+  if (!currentPassword || !newPassword) {
+    throw new AppError('Debes enviar la contraseña actual y la nueva', 400);
+  }
+
+  const user = await getUserById(id);
+  if (!user) throw new AppError('Usuario no encontrado', 404);
+
+  const valid = await bcrypt.compare(currentPassword, user.password);
+  if (!valid) throw new AppError('Contraseña actual incorrecta', 401);
+
+  const newHash = await bcrypt.hash(newPassword, 10);
+  await updateUserPassword(id, newHash);
+
+  res.json({ message: 'Contraseña actualizada correctamente' });
+}
+
+export async function removeUser(req: Request, res: Response) {
+  const id = Number(req.params.id);
+  const user = await getUserById(id);
+  if (!user) throw new AppError('Usuario no encontrado', 404);
+
+  await deleteUser(id);
+  res.json({ message: 'Usuario eliminado correctamente' });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import categoryRoutes from './routes/category.routes';
 import productRoutes from './routes/product.routes';
+import userRoutes from './routes/user.routes';
 import dotenv from 'dotenv';
 import { errorHandler } from './middleware/errorHandler';
 
@@ -13,6 +14,7 @@ app.use(express.json());
 
 app.use('/api/categories', categoryRoutes);
 app.use('/api/products', productRoutes);
+app.use('/api/users', userRoutes);
 
 // ✔ Ruta para verificar que el backend está activo
 app.get('/api', (req, res) => {

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -1,0 +1,6 @@
+export interface User {
+  id?: number;
+  email: string;
+  password: string;   // store hashed password
+  name?: string;
+}

--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { register, login, changePassword, removeUser } from '../controllers/user.controller';
+
+const router = Router();
+
+router.post('/register', register);
+router.post('/login', login);
+router.put('/:id/password', changePassword);
+router.delete('/:id', removeUser);
+
+export default router;

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -1,0 +1,32 @@
+import { db } from '../config/db';
+import { User } from '../models/user.model';
+import bcrypt from 'bcrypt';
+
+export async function createUser(user: Omit<User, 'id'>): Promise<void> {
+  const { email, password, name } = user;
+  const hash = await bcrypt.hash(password, 10);
+  await db.query(
+    'INSERT INTO users (email, password, name) VALUES (?, ?, ?)',
+    [email, hash, name || null]
+  );
+}
+
+export async function getUserByEmail(email: string): Promise<User | null> {
+  const [rows] = await db.query('SELECT * FROM users WHERE email = ?', [email]);
+  const result = (rows as User[])[0];
+  return result || null;
+}
+
+export async function getUserById(id: number): Promise<User | null> {
+  const [rows] = await db.query('SELECT * FROM users WHERE id = ?', [id]);
+  const result = (rows as User[])[0];
+  return result || null;
+}
+
+export async function updateUserPassword(id: number, newHash: string): Promise<void> {
+  await db.query('UPDATE users SET password = ? WHERE id = ?', [newHash, id]);
+}
+
+export async function deleteUser(id: number): Promise<void> {
+  await db.query('DELETE FROM users WHERE id = ?', [id]);
+}


### PR DESCRIPTION
## Summary
- support JWT auth with bcrypt hashed passwords
- add user model, service, controller and routes
- register user routes in main server
- document user endpoints and JWT secret
- update example env file

## Testing
- `npm install bcrypt jsonwebtoken --save` *(fails: 403 Forbidden)*
- `npm run build` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6844d6258c28832d98f385571ab8c0fc